### PR TITLE
fix.  Sort order on rpnow tab is now correctly ascending when ascending is selected.  Fix sort after refresh.

### DIFF
--- a/RpUtils/CHANGELOG.md
+++ b/RpUtils/CHANGELOG.md
@@ -51,3 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 	- Updated to API version 0.0.2
 	- Fixed double calls to enabling SonarController, causing double listeners for opening the map
+
+## [Upcoming]
+	- Updated RP Now table to include a collapsable / sortable tree by server instead of a flat list.

--- a/RpUtils/UI/Tabs/CurrentRpTab.cs
+++ b/RpUtils/UI/Tabs/CurrentRpTab.cs
@@ -163,6 +163,7 @@ namespace RpUtils.UI.Tabs
                 })
                 .ToList();
 
+            this.firstSort = true;
             return countTreeNodes;
         }
 
@@ -176,7 +177,7 @@ namespace RpUtils.UI.Tabs
             bool byLocation = true;
             bool descending = true;
 
-            if (sortSpecs != null && sortSpecs.Value.SpecsCount > 0 && sortSpecs.Value.Specs.SortDirection == ImGuiSortDirection.Descending)
+            if (sortSpecs != null && sortSpecs.Value.SpecsCount > 0 && sortSpecs.Value.Specs.SortDirection == ImGuiSortDirection.Ascending)
             {
                 descending = false;
             }


### PR DESCRIPTION
fix.  Sort order on rpnow tab is now correctly ascending when ascending is selected.  Fix sort after refresh.